### PR TITLE
fix: pass ssids to app

### DIFF
--- a/android/src/main/java/com/reactnativeespidfprovisioning/EspIdfProvisioningModule.kt
+++ b/android/src/main/java/com/reactnativeespidfprovisioning/EspIdfProvisioningModule.kt
@@ -154,7 +154,12 @@ class EspIdfProvisioningModule(reactContext: ReactApplicationContext) : ReactCon
         override fun onWifiListReceived(wifiList: java.util.ArrayList<WiFiAccessPoint>?) {
           val result = WritableNativeArray();
           wifiList?.forEach {
-            result.pushString(it.wifiName)
+            val network: WritableMap = Arguments.createMap();
+            network.putString("name", it.wifiName);
+            network.putInt("rssi", it.rssi);
+            network.putInt("security", it.security);
+
+            result.pushMap(network)
           }
           promise.resolve(result)
         }

--- a/ios/EspIdfProvisioning.swift
+++ b/ios/EspIdfProvisioning.swift
@@ -120,9 +120,9 @@ class EspIdfProvisioning: NSObject {
       EspDevice.shared.espDevice?.scanWifiList{ wifiList, _ in
 
         let networks = wifiList!.map {[
-            "ssid": $0.ssid,
+            "name": $0.ssid,
             "rssi": $0.rssi,
-            "auth": $0.auth.rawValue,
+            "security": $0.auth.rawValue,
         ]}
 
         resolve(networks)

--- a/ios/EspIdfProvisioning.swift
+++ b/ios/EspIdfProvisioning.swift
@@ -118,8 +118,8 @@ class EspIdfProvisioning: NSObject {
     @objc(scanWifiList:withRejecter:)
     func scanWifiList(resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       EspDevice.shared.espDevice?.scanWifiList{ wifiList, _ in
-        dump(wifiList)
-        resolve(wifiList)
+        let ssids = wifiList!.map { $0.ssid }
+        resolve(ssids)
       }
     }
 

--- a/ios/EspIdfProvisioning.swift
+++ b/ios/EspIdfProvisioning.swift
@@ -118,8 +118,14 @@ class EspIdfProvisioning: NSObject {
     @objc(scanWifiList:withRejecter:)
     func scanWifiList(resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       EspDevice.shared.espDevice?.scanWifiList{ wifiList, _ in
-        let ssids = wifiList!.map { $0.ssid }
-        resolve(ssids)
+
+        let networks = wifiList!.map {[
+            "ssid": $0.ssid,
+            "rssi": $0.rssi,
+            "auth": $0.auth.rawValue,
+        ]}
+
+        resolve(networks)
       }
     }
 


### PR DESCRIPTION
There was a small issue on iOS. Now the return value on the scanWifiList is the same on iOS and Android.